### PR TITLE
Add Signin API endpoint

### DIFF
--- a/web/api/user.go
+++ b/web/api/user.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/ostamand/url/web/helper"
+	"github.com/ostamand/url/web/store"
+)
+
+type UserController struct {
+	Storage *store.StorageService
+	User    *helper.UserHelper
+}
+
+type SigninRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type SigninResponse struct {
+	Token string `json:"token"`
+}
+
+func (c *UserController) Signin(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		return
+	}
+	defer req.Body.Close()
+	body, _ := ioutil.ReadAll(req.Body)
+	request := SigninRequest{}
+	_ = json.Unmarshal(body, &request)
+
+	u, err := c.User.VerifyPassword(request.Username, request.Password)
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	// create new session
+	token, expires := helper.GenerateToken()
+	session := store.SessionModel{
+		UserID:    u.ID,
+		Token:     token,
+		CreatedAt: time.Now(),
+		ExpiryAt:  expires,
+	}
+	err = c.Storage.Session.Save(&session)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// prepare response
+	data := SigninResponse{Token: token}
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(data)
+}

--- a/web/api/user.go
+++ b/web/api/user.go
@@ -34,7 +34,7 @@ func (c *UserController) Signin(w http.ResponseWriter, req *http.Request) {
 	_ = json.Unmarshal(body, &request)
 
 	u, err := c.User.VerifyPassword(request.Username, request.Password)
-	if err != nil {
+	if err != nil || (c.User.AdminOnly && !u.Admin) {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}

--- a/web/api/user_test.go
+++ b/web/api/user_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/ostamand/url/web/config"
+	"github.com/ostamand/url/web/helper"
+	"github.com/ostamand/url/web/store"
+	"github.com/ostamand/url/web/store/mysql"
+)
+
+var ctrl *UserController
+var storage *store.StorageService
+
+func init() {
+	wd, _ := os.Getwd()
+	configPath, _ := config.FindIn(wd, os.Getenv("CONFIG_FILE"))
+	params := config.Get(configPath)
+	storage = mysql.InitializeSQL(&params.Db)
+	u := &helper.UserHelper{AdminOnly: false, Storage: storage}
+	ctrl = &UserController{Storage: storage, User: u}
+}
+
+func sendRequest(username string, password string) (*http.Response, SigninResponse) {
+	dataRequest := SigninRequest{
+		Username: username,
+		Password: password,
+	}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(dataRequest)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/signin", b)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	ctrl.Signin(w, req)
+
+	resp := w.Result()
+	dataResponse := SigninResponse{}
+	json.NewDecoder(w.Body).Decode(&dataResponse)
+
+	return resp, dataResponse
+}
+
+func TestSignin(t *testing.T) {
+	// user does not exists
+	resp, data := sendRequest("user", "password")
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Error("User does not exists. Should get a 401")
+	}
+	if data.Token != "" {
+		t.Errorf("Expecting no token but got %s", data.Token)
+	}
+
+	// user does exists
+	u := &store.UserModel{
+		Username: "user",
+		Password: "password",
+		Admin:    false,
+	}
+	storage.User.Save(u)
+	resp, data = sendRequest(u.Username, u.Password)
+	if resp.StatusCode != http.StatusOK {
+		t.Error("Expection status 200 since users exists")
+	}
+	if data.Token == "" {
+		t.Errorf("Expeciting a session token to be provided but got %s", data.Token)
+	}
+
+	userFromSession, err := storage.User.GetBySession(data.Token)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if userFromSession.Username != u.Username {
+		t.Errorf("Expecting to get username %s from session but got %s", u.Username, userFromSession.Username)
+	}
+
+	// cleanup
+	err = storage.Session.DeleteFromToken(data.Token)
+	if err != nil {
+		t.Error(err)
+	}
+	err = storage.User.Delete(userFromSession.ID)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/web/main.go
+++ b/web/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/ostamand/url/web/api"
 	"github.com/ostamand/url/web/config"
 	ctrl "github.com/ostamand/url/web/controller"
 	"github.com/ostamand/url/web/helper"
@@ -21,7 +22,7 @@ func main() {
 
 	// helpers
 	s := mysql.InitializeSQL(&params.Db)
-	userHelper := helper.UserHelper{
+	userHelper := &helper.UserHelper{
 		AdminOnly: params.General.AdminOnly,
 		Session:   helper.SessionHTTP{},
 		Storage:   s,
@@ -30,7 +31,7 @@ func main() {
 	// main controller
 	h := Handler{
 		Storage: s,
-		User:    &userHelper,
+		User:    userHelper,
 	}
 	http.HandleFunc("/", h.redirect)
 	http.HandleFunc("/home", h.home)
@@ -38,7 +39,7 @@ func main() {
 	// user controller
 	u := ctrl.UserController{
 		Storage: s,
-		User:    &userHelper,
+		User:    userHelper,
 	}
 	http.HandleFunc("/signup", u.Signup)
 	http.HandleFunc("/signin", u.Signin)
@@ -47,10 +48,14 @@ func main() {
 	// link controller
 	l := ctrl.LinkController{
 		Storage: s,
-		User:    &userHelper,
+		User:    userHelper,
 	}
 	http.HandleFunc("/link/create", l.Create)
 	http.HandleFunc("/link", l.List)
+
+	// api
+	userAPI := api.UserController{Storage: s, User: userHelper}
+	http.HandleFunc("/api/signin", userAPI.Signin)
 
 	// file server
 	fileServer := http.FileServer(http.Dir("./ui/static/"))

--- a/web/store/mysql/user.go
+++ b/web/store/mysql/user.go
@@ -32,6 +32,13 @@ func (storage userSQL) Delete(id int) error {
 	return err
 }
 
+func (storage userSQL) DeleteFromUsername(username string) error {
+	stmt, _ := storage.db.Prepare("DELETE FROM users WHERE username = ?")
+	defer stmt.Close()
+	_, err := stmt.Exec(username)
+	return err
+}
+
 func (storage userSQL) GetByUsername(username string) (*store.UserModel, error) {
 	query := "SELECT id, username, hashed_password, admin, created_at FROM users WHERE username = ?"
 	u := &store.UserModel{}

--- a/web/store/service.go
+++ b/web/store/service.go
@@ -15,6 +15,7 @@ type UserStorage interface {
 	Delete(id int) error
 	GetBySession(token string) (*UserModel, error)
 	GetByUsername(username string) (*UserModel, error)
+	DeleteFromUsername(username string) error
 }
 
 type SessionStorage interface {


### PR DESCRIPTION
Closes #37

- Add simple links table (#18)
- Add created_at to all tables (#19)
- Add admin flag for dev (#22)
- Create go.yml
- Wrong config path in test (#25)
- Add note to links (#30)
- Add docker compose for unit testing (#31)
- Add admin check tests (#32)
- Open link in new tab (#34)
- Add signin API
- Add test for admin
