### PR TITLE
Add create link to API

### DIFF
--- a/cmd/web/api/link.go
+++ b/cmd/web/api/link.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ostamand/simpurl/cmd/web/helper"
+	"github.com/ostamand/simpurl/internal/store"
+)
+
+type LinkController struct {
+	Storage *store.StorageService
+	User    *helper.UserHelper
+}
+
+type CreateRequest struct {
+	Token       string `json:"token"`
+	Symbol      string `json:"symbol"`
+	URL         string `json:"url"`
+	Description string `json:"description"`
+	Note        string `json:"note"`
+}
+
+func (c *LinkController) Create(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	defer req.Body.Close()
+	body, _ := ioutil.ReadAll(req.Body)
+
+	request := CreateRequest{}
+	_ = json.Unmarshal(body, &request)
+
+	u, err := c.Storage.User.GetBySession(request.Token)
+	if err != nil || (c.User.AdminOnly && !u.Admin) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	l := &store.LinkModel{
+		UserID:      u.ID,
+		Symbol:      request.Symbol,
+		URL:         request.URL,
+		Description: request.Description,
+		Note:        request.Note,
+	}
+	if err = c.Storage.Link.Save(l); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/cmd/web/api/link_test.go
+++ b/cmd/web/api/link_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ostamand/simpurl/cmd/web/helper"
+	"github.com/ostamand/simpurl/internal/config"
+	"github.com/ostamand/simpurl/internal/store"
+	"github.com/ostamand/simpurl/internal/store/mysql"
+)
+
+var linkCtrl *LinkController
+
+func init() {
+	wd, _ := os.Getwd()
+	configPath, _ := config.FindIn(wd, os.Getenv("CONFIG_FILE"))
+	params := config.Get(configPath)
+	storage := mysql.InitializeSQL(&params.Db)
+
+	u := &helper.UserHelper{AdminOnly: false, Storage: storage}
+	linkCtrl = &LinkController{Storage: storage, User: u}
+}
+
+func sendRequest(sessionToken string, l *store.LinkModel) *http.Response {
+	dataRequest := CreateRequest{
+		Token:       sessionToken,
+		Symbol:      l.Symbol,
+		URL:         l.URL,
+		Description: l.Description,
+		Note:        l.Note,
+	}
+	b, _ := json.Marshal(dataRequest)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/link/create", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	linkCtrl.Create(w, req)
+
+	return w.Result()
+}
+
+func createUserAndSession() (*store.UserModel, *store.SessionModel) {
+	u := &store.UserModel{
+		Username: "user",
+		Password: "password",
+		Admin:    false,
+	}
+	userCtrl.Storage.User.Save(u)
+	u, _ = userCtrl.Storage.User.GetByUsername(u.Username)
+
+	token, expires := helper.GenerateToken()
+	session := &store.SessionModel{
+		UserID:    u.ID,
+		Token:     token,
+		CreatedAt: time.Now(),
+		ExpiryAt:  expires,
+	}
+	userCtrl.Storage.Session.Save(session)
+	return u, session
+}
+
+func cleanupUserAndSession(username string, token string) {
+	userCtrl.Storage.User.DeleteFromUsername(username)
+	userCtrl.Storage.Session.DeleteFromToken(token)
+}
+
+func TestCreateNoToken(t *testing.T) {
+	// user and session exists but token not provided
+	u, session := createUserAndSession()
+	defer cleanupUserAndSession(u.Username, session.Token)
+
+	l := &store.LinkModel{}
+	resp := sendRequest("", l)
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Error("No session token provided, should get a 401")
+	}
+}
+
+func TestCreateNoSession(t *testing.T) {
+	u, session := createUserAndSession()
+	userCtrl.Storage.Session.DeleteFromToken(session.Token)
+	defer func() { userCtrl.Storage.User.DeleteFromUsername(u.Username) }()
+
+	l := &store.LinkModel{}
+	resp := sendRequest(session.Token, l)
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Error("No session exists for that user, should get a 401")
+	}
+}
+
+func TestCreateWithSession(t *testing.T) {
+	u, session := createUserAndSession()
+	defer cleanupUserAndSession(u.Username, session.Token)
+
+	l := &store.LinkModel{
+		UserID:      u.ID,
+		URL:         "https://www.google.com/robots.txt",
+		Description: "Robots on Google",
+		Note:        "Run!",
+	}
+	defer func() { userCtrl.Storage.Link.DeleteByURL(l.URL) }()
+	resp := sendRequest(session.Token, l)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Error("User with active session, should get 200")
+	}
+}

--- a/cmd/web/api/user.go
+++ b/cmd/web/api/user.go
@@ -26,6 +26,7 @@ type SigninResponse struct {
 
 func (c *UserController) Signin(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 	defer req.Body.Close()

--- a/internal/store/mysql/link.go
+++ b/internal/store/mysql/link.go
@@ -35,9 +35,6 @@ func (storage *linkSQL) FindBySymbol(symbol string) (*store.LinkModel, error) {
 	var l store.LinkModel
 	query := "SELECT id, symbol, url, description, note, created_at FROM links WHERE symbol = ?"
 	err := storage.db.QueryRow(query, symbol).Scan(&l.ID, &l.Symbol, &l.URL, &l.Description, &l.Note, &l.CreatedAt)
-	if err != nil {
-		log.Println(err)
-	}
 	return &l, err
 }
 
@@ -50,5 +47,12 @@ func (storage *linkSQL) Save(l *store.LinkModel) error {
 	if err != nil {
 		log.Println(err)
 	}
+	return err
+}
+
+func (storage *linkSQL) DeleteByURL(url string) error {
+	stmt, _ := storage.db.Prepare("DELETE FROM links WHERE url = ?")
+	defer stmt.Close()
+	_, err := stmt.Exec(url)
 	return err
 }

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -5,6 +5,7 @@ import "time"
 //TODO refactor this StorageService to include seperate subservices
 
 type LinkStorage interface {
+	DeleteByURL(url string) error
 	GetAll(u *UserModel) (*[]LinkModel, error)
 	FindBySymbol(symbol string) (*LinkModel, error)
 	Save(l *LinkModel) error


### PR DESCRIPTION
Closes #36

- Add simple links table (#18)
- Add created_at to all tables (#19)
- Add admin flag for dev (#22)
- Create go.yml
- Wrong config path in test (#25)
- Add note to links (#30)
- Add docker compose for unit testing (#31)
- Add admin check tests (#32)
- Open link in new tab (#34)
- Add Signin API endpoint (#38)
- Update project structure (#39)
- Add list create
