### PR TITLE
Add Links List API

### DIFF
--- a/cmd/web/controller/api/link.go
+++ b/cmd/web/controller/api/link.go
@@ -23,28 +23,89 @@ type CreateRequest struct {
 	Note        string `json:"note"`
 }
 
-func (c *LinkController) Create(w http.ResponseWriter, req *http.Request) {
-	controller.AllowOrigins(&w) // don't use cookies anyway
+type ListRequest struct {
+	Token       string 	`json:"token"`
+	Limit		int 	`json:"limit"`
+}
+
+type ListResponse struct {
+	Count int `json:"count"`
+	Links []store.LinkModel `json:"links"`
+}
+
+func allowPostRequest(w *http.ResponseWriter, req *http.Request) bool {
+	controller.AllowOrigins(w)
 
 	if req.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusOK)
-		return
+		(*w).WriteHeader(http.StatusOK)
+		return true
 	}
 	if req.Method != http.MethodPost {
-		w.WriteHeader(http.StatusNotFound)
+		(*w).WriteHeader(http.StatusNotFound)
+		return false
+	}
+	return true
+}
+
+func (c *LinkController) getUser(token string) (*store.UserModel, bool) {
+	u, err := c.Storage.User.GetBySession(token)
+	if err != nil || (c.User.AdminOnly && !u.Admin) {
+		return u, false
+	}
+	return u, true
+}
+
+// TODO support filters
+func (c *LinkController) List(w http.ResponseWriter, req *http.Request) {
+	if ok := allowPostRequest(&w, req); !ok {
+		return 
+	}
+
+	defer req.Body.Close()
+	body, _ := ioutil.ReadAll(req.Body)
+
+	request := ListRequest{}
+	_ = json.Unmarshal(body, &request)
+
+	u, ok := c.getUser(request.Token)
+	if !ok {
+		w.WriteHeader(http.StatusUnauthorized)
+		return 
+	}
+
+	// TODO implement limit on GetAll
+	links, err := c.Storage.Link.GetAll(u.ID)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	// TODO setup count
+	response := ListResponse {
+		Count: 0,
+		Links: *links,
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
+
+func (c *LinkController) Create(w http.ResponseWriter, req *http.Request) {
+	if ok := allowPostRequest(&w, req); !ok {
+		return 
+	}
+
 	defer req.Body.Close()
 	body, _ := ioutil.ReadAll(req.Body)
 
 	request := CreateRequest{}
 	_ = json.Unmarshal(body, &request)
 
-	u, err := c.Storage.User.GetBySession(request.Token)
-	if err != nil || (c.User.AdminOnly && !u.Admin) {
+	u, ok := c.getUser(request.Token)
+	if !ok {
 		w.WriteHeader(http.StatusUnauthorized)
-		return
+		return 
 	}
+
 	l := &store.LinkModel{
 		UserID:      u.ID,
 		Symbol:      request.Symbol,
@@ -52,7 +113,7 @@ func (c *LinkController) Create(w http.ResponseWriter, req *http.Request) {
 		Description: request.Description,
 		Note:        request.Note,
 	}
-	if err = c.Storage.Link.Save(l); err != nil {
+	if err := c.Storage.Link.Save(l); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	w.WriteHeader(http.StatusOK)

--- a/cmd/web/controller/link.go
+++ b/cmd/web/controller/link.go
@@ -20,7 +20,7 @@ func (c *LinkController) List(w http.ResponseWriter, req *http.Request) {
 		if !ok {
 			return
 		}
-		links, _ := c.Storage.Link.GetAll(u)
+		links, _ := c.Storage.Link.GetAll(u.ID)
 		viewData := CreateViewData(req, u)
 		data := struct {
 			*ViewData

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -60,7 +60,9 @@ func main() {
 
 	// api
 	linkAPI := api.LinkController{Storage: s, User: userHelper}
+
 	http.HandleFunc("/api/links/create", linkAPI.Create)
+	http.HandleFunc("/api/links", linkAPI.List)
 
 	// file server
 	fileServer := http.FileServer(http.Dir("./web/static/"))
@@ -72,5 +74,6 @@ func main() {
 		port = "8000"
 		log.Printf("defaulting to port %s", port)
 	}
+	
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }

--- a/internal/store/mysql/link.go
+++ b/internal/store/mysql/link.go
@@ -12,7 +12,7 @@ type linkSQL struct {
 	db *sql.DB
 }
 
-func (storage *linkSQL) GetAll(u *store.UserModel) (*[]store.LinkModel, error) {
+func (storage *linkSQL) GetAll(userID int) (*[]store.LinkModel, error) {
 	var links []store.LinkModel
 
 	query := "SELECT id, symbol, url, description, note, created_at FROM links WHERE user_id = ?"
@@ -20,11 +20,11 @@ func (storage *linkSQL) GetAll(u *store.UserModel) (*[]store.LinkModel, error) {
 	stmt, _ := storage.db.Prepare(query)
 	defer stmt.Close()
 
-	rows, _ := stmt.Query(u.ID)
+	rows, _ := stmt.Query(userID)
 	defer rows.Close()
 
 	for rows.Next() {
-		l := store.LinkModel{UserID: u.ID}
+		l := store.LinkModel{UserID: userID}
 		rows.Scan(&l.ID, &l.Symbol, &l.URL, &l.Description, &l.Note, &l.CreatedAt)
 		links = append(links, l)
 	}

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -6,7 +6,7 @@ import "time"
 
 type LinkStorage interface {
 	DeleteByURL(url string) error
-	GetAll(u *UserModel) (*[]LinkModel, error)
+	GetAll(userID int) (*[]LinkModel, error)
 	FindBySymbol(symbol string) (*LinkModel, error)
 	Save(l *LinkModel) error
 }


### PR DESCRIPTION
Closes #45

- Add simple links table (#18)
- Add created_at to all tables (#19)
- Add admin flag for dev (#22)
- Create go.yml
- Wrong config path in test (#25)
- Add note to links (#30)
- Add docker compose for unit testing (#31)
- Add admin check tests (#32)
- Open link in new tab (#34)
- Add Signin API endpoint (#38)
- Update project structure (#39)
- Add list create (#44)
- Add CLI (#48)
- Add links list to API
